### PR TITLE
[Neo , 쑤]  Step4 - 이미지 라이브 포토 표시 

### DIFF
--- a/PhotosApp/PhotosApp/ImageCell.swift
+++ b/PhotosApp/PhotosApp/ImageCell.swift
@@ -6,9 +6,12 @@
 //
 
 import UIKit
+import Photos
+import PhotosUI
 
 class ImageCell: UICollectionViewCell {
     @IBOutlet weak var imageView : UIImageView!
+    @IBOutlet weak var livePhotoStateView: UIImageView!
     
     static let identifier = "ImageCell"
     
@@ -18,6 +21,10 @@ class ImageCell: UICollectionViewCell {
     
     static func nib() -> UINib {
         return UINib(nibName: identifier, bundle: nil)
+    }
+    
+    func check(_ asset : PHAsset) -> UIImage {
+        return asset.mediaSubtypes == .photoLive ? PHLivePhotoView.livePhotoBadgeImage(options: .overContent) : UIImage()
     }
     
     func setImage(_ image: UIImage?) {

--- a/PhotosApp/PhotosApp/ImageCell.xib
+++ b/PhotosApp/PhotosApp/ImageCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,17 +19,27 @@
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Nzl-ba-vfO">
                         <rect key="frame" x="0.0" y="0.0" width="493" height="275"/>
                     </imageView>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="thY-uv-wkj">
+                        <rect key="frame" x="463" y="0.0" width="30" height="30"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="30" id="YEe-cz-reh"/>
+                            <constraint firstAttribute="height" constant="30" id="zZz-Wf-5iD"/>
+                        </constraints>
+                    </imageView>
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="bottom" secondItem="Nzl-ba-vfO" secondAttribute="bottom" id="FRI-Nr-idA"/>
                     <constraint firstItem="Nzl-ba-vfO" firstAttribute="top" secondItem="gRZ-R5-BjP" secondAttribute="top" id="Zxo-0x-hrb"/>
                     <constraint firstAttribute="trailing" secondItem="Nzl-ba-vfO" secondAttribute="trailing" id="grp-JU-M4J"/>
+                    <constraint firstAttribute="trailing" secondItem="thY-uv-wkj" secondAttribute="trailing" id="meF-h7-WDu"/>
+                    <constraint firstItem="thY-uv-wkj" firstAttribute="top" secondItem="gRZ-R5-BjP" secondAttribute="top" id="pnb-p0-6if"/>
                     <constraint firstItem="Nzl-ba-vfO" firstAttribute="leading" secondItem="gRZ-R5-BjP" secondAttribute="leading" id="yh3-4r-rOr"/>
                 </constraints>
             </collectionViewCellContentView>
             <size key="customSize" width="493" height="275"/>
             <connections>
                 <outlet property="imageView" destination="Nzl-ba-vfO" id="z1C-zG-3Af"/>
+                <outlet property="livePhotoStateView" destination="thY-uv-wkj" id="SQm-sX-cXV"/>
             </connections>
             <point key="canvasLocation" x="200.72463768115944" y="124.21875"/>
         </collectionViewCell>

--- a/PhotosApp/PhotosApp/ImageCollectionDataSourece.swift
+++ b/PhotosApp/PhotosApp/ImageCollectionDataSourece.swift
@@ -8,6 +8,7 @@
 import Foundation
 import UIKit
 import Photos
+import PhotosUI
 
 class ImageCollectionDataSource : NSObject, UICollectionViewDataSource {
     
@@ -29,6 +30,7 @@ class ImageCollectionDataSource : NSObject, UICollectionViewDataSource {
         }
         let asset = imageFetch.object(at: indexPath.row)
         imageManager.requestImage(for: asset, targetSize: CGSize(width: 100, height: 100), contentMode: .aspectFit, options: nil) { (image, _) in
+            cell.livePhotoStateView.image = cell.check(asset)
             cell.setImage(image)
         }
         return cell


### PR DESCRIPTION
## 주요 작업 목록
- [x] NavigationBar에 우측 바버튼을 Done버튼을 추가.
- [x] Cell 에 우측 상단에 Live Photo 인지 표시하는 이미지를 추가하고, asset의 mediaSubTypes에서 .photoLive 서브타입을 포함하는지  확인해서 있을때만 라이브포토 이미지(PHLivePhotoView 활용)를 표시.
- [x] 콜랙션뷰에서 다중 선택이 가능하도록 설정을 변경하고, UICollectionViewDelegate를 구현해서 선택된 이미지 Asset을 한꺼번에 처리하도록 구현.
- [x] 셀을 선택한 것인지 아닌지 시각적으로 구분할 수 있도록 구현한다. 단, layer.border 관련 속성을 쓰지말고 selectedBackgroundView 를 활용.
- [x] 선택한 셀이 없으면 Done 버튼을 비활성화 시키고, 3개 이상 선택되면 버튼을 활성화.
- [ ] 이미지를 여러 개 선택한 이후에 Done 버튼을 누르면, AVAssetWriter 클래스를 활용해서 3초 길이 비디오로 만들어서 저장.
- [ ] 저장한 동영상은 사진보관함 보여야함.

## 학습 키워드
 - PhotosUI
 - PhotoLiveView
 - selectedBackgroundView

## 고민과 해결
 라이브포토 이미지를 가져오기 위해 PhotoLiveView의 livePhotoBadgeImage를 활용
 cell의 재사용을 고려하면서 라이브포토 표시 하도록 구현
 